### PR TITLE
Garfield: Add default shortcut for plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,13 @@
       "default_icon": "icon.png",
       "default_popup": "popup.html"
     },
+    "commands": {
+        "_execute_browser_action": {
+            "suggested_key": {
+                "default": "MacCtrl+P"
+            }
+        }
+    },
     "manifest_version": 2,
     "content_security_policy": "script-src 'self' https://ajax.googleapis.com; object-src 'self'"
   }


### PR DESCRIPTION
We shall assign a default shortcut on "Ctrl+P" rather than requesting user to do that manually. 
Then the name of plugin makes better sense.

_Since `Crtl` will be translated to `Command` in suggested_key field on macOS, `MacCtrl` is used here to make it will be `Ctrl`+`P` anywhere._