### PR TITLE
Fix uninstallable issue aroused by 'MacCtrl'

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,9 @@
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {
-                "default": "MacCtrl+P"
+                "default": "Ctrl+P",
+                "windows": "Ctrl+P",
+                "mac": "MacCtrl+P"
             }
         }
     },


### PR DESCRIPTION
My colleague have suffered uninstallable issue on Windows chrome.   :(

It was caused by my ignorant on such a postscript in [developer doc](https://developer.chrome.com/extensions/commands) about chrome.commands:
`Specifying 'MacCtrl' under "default" will cause the extension to be uninstallable.`

That's terrible, and must be corrected. 